### PR TITLE
full Ubuntu(+) compatbility, pre-fix soon to be issues

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 # Add colors for text
-export PrefixColor='\033[1;34m'
-export BoldColor='\033[1;37m'
-export NC='\033[0m'
+PrefixColor='\033[1;34m'
+BoldColor='\033[1;37m'
+NC='\033[0m'
 
 crd=$PWD
 
@@ -70,8 +70,12 @@ installDragonBuild() {
     distr=$(uname -s)
     arch=$(uname -p)
     if [ "$distr" == "Darwin" ]; then 
-        if [ "$arch" == "arm" ] || [ "$arch" == "arm64" ]; then iosInstall
-        else macosInstall
+        if [ "$arch" == "arm" ] || [ "$arch" == "arm64" ]; then
+	    if [ "${USER}" == "mobile" ]; then
+	        iosInstall
+	    else
+                macosInstall
+	    fi
         fi
     else linuxInstall
     fi


### PR DESCRIPTION
Removed ldid from $need by default and added auto toolchain grabber, as this will be needed for both Linux (sbingner toolchain) and macOS (Xcode 11.7 toolchain since 12.0+ has arm64e issues)